### PR TITLE
Add Code of Conduct and guidelines to contributing page

### DIFF
--- a/courses/CODE_OF_CONDUCT.md
+++ b/courses/CODE_OF_CONDUCT.md
@@ -1,0 +1,42 @@
+LinkedIn Open Source Code of Conduct
+-------------------------------------
+
+This code of conduct outlines expectations for participation in LinkedIn-managed open source communities, as well as steps for reporting unacceptable behavior. We are committed to providing a welcoming and inspiring community for all. People violating this code of conduct may be banned from the community.
+
+Our open source communities strive to:
+
+* **Be friendly and patient:** Remember you might not be communicating in someone else's primary spoken or programming language, and others may not have your level of understanding.
+* **Be welcoming:** Our communities welcome and support people of all backgrounds and identities. This includes, but is not limited to members of any race, ethnicity, culture, national origin, color, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
+* **Be respectful:** We are a world-wide community of professionals, and we conduct ourselves professionally. Disagreement is no excuse for poor behavior and poor manners. Disrespectful and unacceptable behavior includes, but is not limited to:
+    * Violent threats or language.
+    * Discriminatory or derogatory jokes and language.
+    * Posting sexually explicit or violent material.
+    * Posting, or threatening to post, people's personally identifying information ("doxing").
+    * Insults, especially those using discriminatory terms or slurs.
+    * Behavior that could be perceived as sexual attention.
+    * Advocating for or encouraging any of the above behaviors.
+* **Understand disagreements:** Disagreements, both social and technical, are useful learning opportunities. Seek to understand the other viewpoints and resolve differences constructively.
+* This code is not exhaustive or complete. It serves to capture our common understanding of a productive, collaborative environment. We expect the code to be followed in spirit as much as in the letter.
+
+### Scope
+
+This code of conduct applies to all repos and communities for LinkedIn-managed open source projects regardless of whether or not the repo explicitly calls out its use of this code. The code also applies in public spaces when an individual is representing a project or its community. Examples include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+Note: Some LinkedIn-managed communities have codes of conduct that pre-date this document and issue resolution process. While communities are not required to change their code, they are expected to use the resolution process outlined here. The review team will coordinate with the communities involved to address your concerns.
+
+### Reporting Code of Conduct Issues
+
+We encourage all communities to resolve issues on their own whenever possible. This builds a broader and deeper understanding and ultimately a healthier interaction. In the event that an issue cannot be resolved locally, please feel free to report your concerns by contacting [oss@linkedin.com](mailto:oss@linkedin.com).
+
+In your report please include:
+
+*   Your contact information.
+*   Names (real, usernames or pseudonyms) of any individuals involved. If there are additional witnesses, please include them as well.
+*   Your account of what occurred, and if you believe the incident is ongoing. If there is a publicly available record (e.g. a mailing list archive or a public chat log), please include a link or attachment.
+*   Any additional information that may be helpful.
+
+All reports will be reviewed by a multi-person team and will result in a response that is deemed necessary and appropriate to the circumstances. Where additional perspectives are needed, the team may seek insight from others with relevant expertise or experience. The confidentiality of the person reporting the incident will be kept at all times. Involved parties are never part of the review team.
+
+Anyone asked to stop unacceptable behavior is expected to comply immediately. If an individual engages in unacceptable behavior, the review team may take any action they deem appropriate, including a permanent ban from the community.
+
+_This code of conduct is based on the [Microsoft](https://opensource.microsoft.com/codeofconduct/) Open Source Code of Conduct which was based on the [template](http://todogroup.org/opencodeofconduct) established by the [TODO Group](http://todogroup.org/) and used by numerous other large communities (e.g., [Facebook](https://code.facebook.com/pages/876921332402685/open-source-code-of-conduct), [Yahoo](https://yahoo.github.io/codeofconduct), [Twitter](https://engineering.twitter.com/opensource/code-of-conduct), [GitHub](http://todogroup.org/opencodeofconduct/#opensource@github.com)) and the Scope section from the [Contributor Covenant version 1.4](http://contributor-covenant.org/version/1/4/)._

--- a/courses/CODE_OF_CONDUCT.md
+++ b/courses/CODE_OF_CONDUCT.md
@@ -1,6 +1,3 @@
-LinkedIn Open Source Code of Conduct
--------------------------------------
-
 This code of conduct outlines expectations for participation in LinkedIn-managed open source communities, as well as steps for reporting unacceptable behavior. We are committed to providing a welcoming and inspiring community for all. People violating this code of conduct may be banned from the community.
 
 Our open source communities strive to:

--- a/courses/CONTRIBUTING.md
+++ b/courses/CONTRIBUTING.md
@@ -8,7 +8,7 @@ As a contributor, you represent that the content you submit is not plagiarised. 
 Ensure that you adhere to the following guidelines:
 
 * Should be about principles and concepts that can be applied in any company or individual project. Do not focus on particular tools or tech stack(which usually change over time).
-* Adhere to the Code of Conduct.
+* Adhere to the [Code of Conduct](/school-of-sre/CODE_OF_CONDUCT/).
 * Should be relevant to the roles and responsibilities of an SRE.
 * Should be locally tested (see steps for testing) and well formatted.
 * It is good practice to open an issue first and discuss your changes before submitting a pull request. This way, you can incorporate ideas from others before you even start.
@@ -17,6 +17,8 @@ Ensure that you adhere to the following guidelines:
 Run the following commands to build and view the site locally before opening a PR.
 
 ```
+python3 -m venv .venv
+source .venv/bin/activate
 pip install -r requirements.txt
 mkdocs build
 mkdocs serve

--- a/courses/CONTRIBUTING.md
+++ b/courses/CONTRIBUTING.md
@@ -2,9 +2,16 @@ We realise that the initial content we created is just a starting point and our 
 
 As a contributor, you represent that the content you submit is not plagiarised. By submitting the content, you (and, if applicable, your employer) are licensing the submitted content to LinkedIn and the open source community subject to the Creative Commons Attribution 4.0 International Public License.
 
-We suggest to open an issue first and seek advice for your changes before submitting a pull request.
-
 *Repository URL*: [https://github.com/linkedin/school-of-sre](https://github.com/linkedin/school-of-sre)
+
+### Contributing Guidelines
+Ensure that you adhere to the following guidelines:
+
+* Should be about principles and concepts that can be applied in any company or individual project. Do not focus on particular tools or tech stack(which usually change over time).
+* Adhere to the Code of Conduct.
+* Should be relevant to the roles and responsibilities of an SRE.
+* Should be locally tested (see steps for testing) and well formatted.
+* It is good practice to open an issue first and discuss your changes before submitting a pull request. This way, you can incorporate ideas from others before you even start.
 
 ### Building and testing locally
 Run the following commands to build and view the site locally before opening a PR.
@@ -14,3 +21,8 @@ pip install -r requirements.txt
 mkdocs build
 mkdocs serve
 ```
+
+### Opening a PR
+Follow the [https://guides.github.com/introduction/flow/](GitHub PR workflow) for your contributions.
+
+Fork this repo, create a feature branch, commit your changes and open a PR to this repo.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,7 @@ nav:
     - Writing Secure code: security/writing_secure_code.md
     - Conclusion: security/conclusion.md
 - Contribute: CONTRIBUTING.md
+- Code of Conduct: CODE_OF_CONDUCT.md
 copyright: "Copyright 2020 LinkedIn Corporation. All Rights Reserved. Licensed under the Creative Commons Attribution 4.0 International Public License"
 extra:
     social:


### PR DESCRIPTION
Added a guidelines and PR section to the contributing page. Resolves #45 