### PR TITLE
Fix the link for "Docker Security" book

### DIFF
--- a/courses/security/conclusion.md
+++ b/courses/security/conclusion.md
@@ -9,7 +9,7 @@ This course provides fundamental everyday knowledge on security domain which wil
 Some books that would be a great resource
 
 - Holistic Info-Sec for Web Developers <https://holisticinfosecforwebdevelopers.com/>- Free and downloadable book series with very broad and deep coverage of what Web Developers and DevOps Engineers need to know in order to create robust, reliable, maintainable and secure software, networks and other, that are delivered continuously, on time, with no nasty surprises
-- Docker Security - Quick Reference: For DevOps Engineers <https://holisticinfosecforwebdevelopers.com/> - A book on understanding the Docker security defaults, how to improve them (theory and practical), along with many tools and techniques.
+- Docker Security - Quick Reference: For DevOps Engineers <https://leanpub.com/dockersecurity-quickreference> - A book on understanding the Docker security defaults, how to improve them (theory and practical), along with many tools and techniques.
 - How to Hack Like a Legend <https://amzn.to/2uWh1Up>- A hacker’s tale breaking into a secretive offshore company, Sparc Flow, 2018
 - How to Investigate Like a Rockstar <https://books2read.com/u/4jDWoZ>- Live a real crisis to master the secrets of forensic analysis, Sparc Flow, 2017
 - Real World Cryptography <https://www.manning.com/books/real-world-cryptography>- This early-access book teaches you applied cryptographic techniques to understand and apply security at every level of your systems and applications.


### PR DESCRIPTION
The existing link was wrong.