### PR TITLE
Fix unexpected render with double quote

### DIFF
--- a/courses/linux_basics/linux_server_administration.md
+++ b/courses/linux_basics/linux_server_administration.md
@@ -109,7 +109,7 @@ The passwd command is used to create or modify passwords for a user.
 In the above examples, we have not assigned any password for users
 'shivam' or 'amit' while creating them.
 
-`!!` in an account entry in shadow means the account of an user has
+"!!" in an account entry in shadow means the account of an user has
 been created, but not yet given a password.
 
 ![](images/linux/admin/image13.png)

--- a/courses/linux_basics/linux_server_administration.md
+++ b/courses/linux_basics/linux_server_administration.md
@@ -109,7 +109,7 @@ The passwd command is used to create or modify passwords for a user.
 In the above examples, we have not assigned any password for users
 'shivam' or 'amit' while creating them.
 
-\"!!\" in an account entry in shadow means the account of an user has
+`!!` in an account entry in shadow means the account of an user has
 been created, but not yet given a password.
 
 ![](images/linux/admin/image13.png)


### PR DESCRIPTION
Double quotes which escape with back slashes doesn't rendered well [in the document](https://linkedin.github.io/school-of-sre/linux_basics/linux_server_administration/#passwd).

![image](https://user-images.githubusercontent.com/13946679/103624129-098d7c00-4f74-11eb-9e52-7d931a6df2cf.png)

I tried to left double quotes without backslashes.