### PR TITLE
Remove shell prompt so shell commands are easier to read

### DIFF
--- a/courses/git/branches.md
+++ b/courses/git/branches.md
@@ -7,8 +7,8 @@ Using branches, there can exist multiple lines of histories and we can checkout 
 Let's create a branch and see how it looks like:
 
 ```bash
-spatel1-mn1:school-of-sre spatel1$ git branch b1
-spatel1-mn1:school-of-sre spatel1$ git log --oneline --graph
+$ git branch b1
+$ git log --oneline --graph
 * 7f3b00e (HEAD -> master, b1) adding file 2
 * df2fb7a adding file 1
 ```
@@ -16,9 +16,9 @@ spatel1-mn1:school-of-sre spatel1$ git log --oneline --graph
 We create a branch called `b1`. Git log tells us that b1 also points to the last commit (7f3b00e) but the `HEAD` is still pointing to master. If you remember, HEAD points to the commit/reference wherever you are checkout to. So if we checkout to `b1`, HEAD should point to that. Let's confirm:
 
 ```bash
-spatel1-mn1:school-of-sre spatel1$ git checkout b1
+$ git checkout b1
 Switched to branch 'b1'
-spatel1-mn1:school-of-sre spatel1$ git log --oneline --graph
+$ git log --oneline --graph
 * 7f3b00e (HEAD -> b1, master) adding file 2
 * df2fb7a adding file 1
 ```
@@ -29,38 +29,38 @@ At this moment, we are checked out on branch `b1`, so making a new commit will a
 
 ```bash
 # Creating a file and making a commit
-spatel1-mn1:school-of-sre spatel1$ echo "I am a file in b1 branch" > b1.txt
-spatel1-mn1:school-of-sre spatel1$ git add b1.txt
-spatel1-mn1:school-of-sre spatel1$ git commit -m "adding b1 file"
+$ echo "I am a file in b1 branch" > b1.txt
+$ git add b1.txt
+$ git commit -m "adding b1 file"
 [b1 872a38f] adding b1 file
 1 file changed, 1 insertion(+)
 create mode 100644 b1.txt
 
 # The new line of history
-spatel1-mn1:school-of-sre spatel1$ git log --oneline --graph
+$ git log --oneline --graph
 * 872a38f (HEAD -> b1) adding b1 file
 * 7f3b00e (master) adding file 2
 * df2fb7a adding file 1
-spatel1-mn1:school-of-sre spatel1$
+$
 ```
 
 Do note that master is still pointing to the old commit it was pointing to. We can now checkout to master branch and make commits there. This will result in another line of history starting from commit 7f3b00e.
 
 ```bash
 # checkout to master branch
-spatel1-mn1:school-of-sre spatel1$ git checkout master
+$ git checkout master
 Switched to branch 'master'
 
 # Creating a new commit on master branch
-spatel1-mn1:school-of-sre spatel1$ echo "new file in master branch" > master.txt
-spatel1-mn1:school-of-sre spatel1$ git add master.txt
-spatel1-mn1:school-of-sre spatel1$ git commit -m "adding master.txt file"
+$ echo "new file in master branch" > master.txt
+$ git add master.txt
+$ git commit -m "adding master.txt file"
 [master 60dc441] adding master.txt file
 1 file changed, 1 insertion(+)
 create mode 100644 master.txt
 
 # The history line
-spatel1-mn1:school-of-sre spatel1$ git log --oneline --graph
+$ git log --oneline --graph
 * 60dc441 (HEAD -> master) adding master.txt file
 * 7f3b00e adding file 2
 * df2fb7a adding file 1
@@ -69,10 +69,10 @@ spatel1-mn1:school-of-sre spatel1$ git log --oneline --graph
 Notice how branch b1 is not visible here since we are on the master. Let's try to visualize both to get the whole picture:
 
 ```bash
-spatel1-mn1:school-of-sre spatel1$ git log --oneline --graph --all
+$ git log --oneline --graph --all
 * 60dc441 (HEAD -> master) adding master.txt file
 | * 872a38f (b1) adding b1 file
-|/ 
+|/
 * 7f3b00e adding file 2
 * df2fb7a adding file 1
 ```
@@ -88,10 +88,10 @@ Now say the feature you were working on branch `b1` is complete and you need to 
 Here is the current history:
 
 ```bash
-spatel1-mn1:school-of-sre spatel1$ git log --oneline --graph --all
+$ git log --oneline --graph --all
 * 60dc441 (HEAD -> master) adding master.txt file
 | * 872a38f (b1) adding b1 file
-|/ 
+|/
 * 7f3b00e adding file 2
 * df2fb7a adding file 1
 ```
@@ -99,17 +99,17 @@ spatel1-mn1:school-of-sre spatel1$ git log --oneline --graph --all
 **Option 1: Directly merge the branch.** Merging the branch b1 into master will result in a new merge commit. This will merge changes from two different lines of history and create a new commit of the result.
 
 ```bash
-spatel1-mn1:school-of-sre spatel1$ git merge b1
+$ git merge b1
 Merge made by the 'recursive' strategy.
 b1.txt | 1 +
 1 file changed, 1 insertion(+)
 create mode 100644 b1.txt
-spatel1-mn1:school-of-sre spatel1$ git log --oneline --graph --all
+$ git log --oneline --graph --all
 *   8fc28f9 (HEAD -> master) Merge branch 'b1'
 |\
 | * 872a38f (b1) adding b1 file
 * | 60dc441 adding master.txt file
-|/ 
+|/
 * 7f3b00e adding file 2
 * df2fb7a adding file 1
 ```
@@ -119,12 +119,12 @@ You can see a new merge commit created (8fc28f9). You will be prompted for the c
 First let's [reset](https://git-scm.com/docs/git-reset) our last merge and go to the previous state.
 
 ```bash
-spatel1-mn1:school-of-sre spatel1$ git reset --hard 60dc441
+$ git reset --hard 60dc441
 HEAD is now at 60dc441 adding master.txt file
-spatel1-mn1:school-of-sre spatel1$ git log --oneline --graph --all
+$ git log --oneline --graph --all
 * 60dc441 (HEAD -> master) adding master.txt file
 | * 872a38f (b1) adding b1 file
-|/ 
+|/
 * 7f3b00e adding file 2
 * df2fb7a adding file 1
 ```
@@ -133,16 +133,16 @@ spatel1-mn1:school-of-sre spatel1$ git log --oneline --graph --all
 
 ```bash
 # Switch to b1
-spatel1-mn1:school-of-sre spatel1$ git checkout b1
+$ git checkout b1
 Switched to branch 'b1'
 
 # Rebase (b1 which is current branch) on master
-spatel1-mn1:school-of-sre spatel1$ git rebase master
+$ git rebase master
 First, rewinding head to replay your work on top of it...
 Applying: adding b1 file
 
 # The result
-spatel1-mn1:school-of-sre spatel1$ git log --oneline --graph --all
+$ git log --oneline --graph --all
 * 5372c8f (HEAD -> b1) adding b1 file
 * 60dc441 (master) adding master.txt file
 * 7f3b00e adding file 2
@@ -153,11 +153,11 @@ You can see `b1` which had 1 commit. That commit's parent was `7f3b00e`. But sin
 
 ```bash
 # checkout to master since we want to merge code into master
-spatel1-mn1:school-of-sre spatel1$ git checkout master
+$ git checkout master
 Switched to branch 'master'
 
 # the current history, where b1 is based on master
-spatel1-mn1:school-of-sre spatel1$ git log --oneline --graph --all
+$ git log --oneline --graph --all
 * 5372c8f (b1) adding b1 file
 * 60dc441 (HEAD -> master) adding master.txt file
 * 7f3b00e adding file 2
@@ -165,7 +165,7 @@ spatel1-mn1:school-of-sre spatel1$ git log --oneline --graph --all
 
 
 # Performing the merge, notice the "fast-forward" message
-spatel1-mn1:school-of-sre spatel1$ git merge b1
+$ git merge b1
 Updating 60dc441..5372c8f
 Fast-forward
 b1.txt | 1 +
@@ -173,7 +173,7 @@ b1.txt | 1 +
 create mode 100644 b1.txt
 
 # The Result
-spatel1-mn1:school-of-sre spatel1$ git log --oneline --graph --all
+$ git log --oneline --graph --all
 * 5372c8f (HEAD -> master, b1) adding b1 file
 * 60dc441 adding master.txt file
 * 7f3b00e adding file 2

--- a/courses/git/git-basics.md
+++ b/courses/git/git-basics.md
@@ -33,19 +33,19 @@ Any folder can be converted into a git repository. After executing the following
 
 ```bash
 # creating an empty folder and changing current dir to it
-spatel1-mn1:~ spatel1$ cd /tmp
-spatel1-mn1:tmp spatel1$ mkdir school-of-sre
-spatel1-mn1:tmp spatel1$ cd school-of-sre/
+$ cd /tmp
+$ mkdir school-of-sre
+$ cd school-of-sre/
 
 # initialize a git repo
-spatel1-mn1:school-of-sre spatel1$ git init
+$ git init
 Initialized empty Git repository in /private/tmp/school-of-sre/.git/
 ```
 
 As the output says, an empty git repo has been initialized in our folder. Let's take a look at what is there.
 
 ```bash
-spatel1-mn1:school-of-sre spatel1$ ls .git/
+$ ls .git/
 HEAD        config      description hooks       info        objects     refs
 ```
 
@@ -56,8 +56,8 @@ There are a bunch of folders and files in the `.git` folder. As I said, all thes
 Now as you might already know, let us create a new file in our repo (we will refer to the folder as _repo_ now.) And see git status
 
 ```bash
-spatel1-mn1:school-of-sre spatel1$ echo "I am file 1" > file1.txt
-spatel1-mn1:school-of-sre spatel1$ git status
+$ echo "I am file 1" > file1.txt
+$ git status
 On branch master
 
 No commits yet
@@ -73,8 +73,8 @@ nothing added to commit but untracked files present (use "git add" to track)
 The current git status says `No commits yet` and there is one untracked file. Since we just created the file, git is not tracking that file. We explicitly need to ask git to track files and folders. (also checkout [gitignore](https://git-scm.com/docs/gitignore)) And how we do that is via `git add` command as suggested in the above output. Then we go ahead and create a  commit.
 
 ```bash
-spatel1-mn1:school-of-sre spatel1$ git add file1.txt
-spatel1-mn1:school-of-sre spatel1$ git status
+$ git add file1.txt
+$ git status
 On branch master
 
 No commits yet
@@ -84,7 +84,7 @@ Changes to be committed:
 
        new file:   file1.txt
 
-spatel1-mn1:school-of-sre spatel1$ git commit -m "adding file 1"
+$ git commit -m "adding file 1"
 [master (root-commit) df2fb7a] adding file 1
 1 file changed, 1 insertion(+)
 create mode 100644 file1.txt
@@ -101,9 +101,9 @@ Commit is a snapshot of the repo. Whenever a commit is made, a snapshot of the c
 Let us create one more file and commit the change. It would look the same as the previous commit we made.
 
 ```bash
-spatel1-mn1:school-of-sre spatel1$ echo "I am file 2" > file2.txt
-spatel1-mn1:school-of-sre spatel1$ git add file2.txt
-spatel1-mn1:school-of-sre spatel1$ git commit -m "adding file 2"
+$ echo "I am file 2" > file2.txt
+$ git add file2.txt
+$ git commit -m "adding file 2"
 [master 7f3b00e] adding file 2
 1 file changed, 1 insertion(+)
 create mode 100644 file2.txt
@@ -116,7 +116,7 @@ A new commit with ID `7f3b00e` has been created. You can issue `git status` at a
 Now that we have two commits, let's visualize them:
 
 ```bash
-spatel1-mn1:school-of-sre spatel1$ git log --oneline --graph
+$ git log --oneline --graph
 * 7f3b00e (HEAD -> master) adding file 2
 * df2fb7a adding file 1
 ```
@@ -134,7 +134,7 @@ spatel1-mn1:school-of-sre spatel1$ git log --oneline --graph
 As I just said, the two commits we just made are linked via tree like data structure and we saw how they are linked. But let's actually verify it. Everything in git is an object. Newly created files are stored as an object. Changes to file are stored as an objects and even commits are objects. To view contents of an object we can use the following command with the object's ID. We will take a look at the contents of the second commit
 
 ```bash
-spatel1-mn1:school-of-sre spatel1$ git cat-file -p 7f3b00e
+$ git cat-file -p 7f3b00e
 tree ebf3af44d253e5328340026e45a9fa9ae3ea1982
 parent df2fb7a61f5d40c1191e0fdeb0fc5d6e7969685a
 author Sanket Patel <spatel1@linkedin.com> 1603273316 -0700
@@ -146,7 +146,7 @@ adding file 2
 Take a note of `parent` attribute in the above output. It points to the commit id of the first commit we made. So this proves that they are linked! Additionally you can see the second commit's message in this object. As I said all this magic is enabled by `.git` folder and the object to which we are looking at also is in that folder.
 
 ```bash
-spatel1-mn1:school-of-sre spatel1$ ls .git/objects/7f/3b00eaa957815884198e2fdfec29361108d6a9
+$ ls .git/objects/7f/3b00eaa957815884198e2fdfec29361108d6a9
 .git/objects/7f/3b00eaa957815884198e2fdfec29361108d6a9
 ```
 
@@ -158,11 +158,11 @@ We already can see two commits (versions) in our git log. One thing a version co
 
 ```bash
 # Current contents, two files present
-patel1-mn1:school-of-sre spatel1$ ls
+$ ls
 file1.txt file2.txt
 
 # checking out to (an older) commit
-spatel1-mn1:school-of-sre spatel1$ git checkout df2fb7a
+$ git checkout df2fb7a
 Note: checking out 'df2fb7a'.
 
 You are in 'detached HEAD' state. You can look around, make experimental
@@ -177,7 +177,7 @@ do so (now or later) by using -b with the checkout command again. Example:
 HEAD is now at df2fb7a adding file 1
 
 # checking contents, can verify it has old contents
-spatel1-mn1:school-of-sre spatel1$ ls
+$ ls
 file1.txt
 ```
 
@@ -190,12 +190,12 @@ I mention in the previous section that we need a _reference_ to the version. By 
 Similarly, master is also a reference (to a branch). Since git uses tree like structure to store commits, there of course will be branches. And the default branch is called `master`. Master (or any branch reference) will point to the latest commit in the branch. Even though we have checked out to the previous commit in out repo, `master` still points to the latest commit. And we can get back to the latest version by checkout at `master` reference
 
 ```bash
-spatel1-mn1:school-of-sre spatel1$ git checkout master
+$ git checkout master
 Previous HEAD position was df2fb7a adding file 1
 Switched to branch 'master'
 
 # now we will see latest code, with two files
-spatel1-mn1:school-of-sre spatel1$ ls
+$ ls
 file1.txt file2.txt
 ```
 
@@ -206,7 +206,7 @@ Note, instead of `master` in above command, we could have used commit's ID as we
 Let's look at the state of things. Two commits, `master` and `HEAD` references are pointing to the latest commit
 
 ```bash
-spatel1-mn1:school-of-sre spatel1$ git log --oneline --graph
+$ git log --oneline --graph
 * 7f3b00e (HEAD -> master) adding file 2
 * df2fb7a adding file 1
 ```
@@ -214,7 +214,7 @@ spatel1-mn1:school-of-sre spatel1$ git log --oneline --graph
 The magic? Let's examine these files:
 
 ```bash
-spatel1-mn1:school-of-sre spatel1$ cat .git/refs/heads/master
+$ cat .git/refs/heads/master
 7f3b00eaa957815884198e2fdfec29361108d6a9
 ```
 
@@ -223,7 +223,7 @@ Viola! Where master is pointing to is stored in a file. **Whenever git needs to 
 Similary, for `HEAD` reference:
 
 ```bash
-spatel1-mn1:school-of-sre spatel1$ cat .git/HEAD
+$ cat .git/HEAD
 ref: refs/heads/master
 ```
 
@@ -234,7 +234,7 @@ We can see `HEAD` is pointing to a reference called `refs/heads/master`. So `HEA
 We discussed how git will update the files as we execute commands. But let's try to do it ourselves, by hand, and see what happens.
 
 ```bash
-spatel1-mn1:school-of-sre spatel1$ git log --oneline --graph
+$ git log --oneline --graph
 * 7f3b00e (HEAD -> master) adding file 2
 * df2fb7a adding file 1
 ```
@@ -242,13 +242,13 @@ spatel1-mn1:school-of-sre spatel1$ git log --oneline --graph
 Now let's change master to point to the previous/first commit.
 
 ```bash
-spatel1-mn1:school-of-sre spatel1$ echo df2fb7a61f5d40c1191e0fdeb0fc5d6e7969685a > .git/refs/heads/master
-spatel1-mn1:school-of-sre spatel1$ git log --oneline --graph
+$ echo df2fb7a61f5d40c1191e0fdeb0fc5d6e7969685a > .git/refs/heads/master
+$ git log --oneline --graph
 * df2fb7a (HEAD -> master) adding file 1
 
 # RESETTING TO ORIGINAL
-spatel1-mn1:school-of-sre spatel1$ echo 7f3b00eaa957815884198e2fdfec29361108d6a9 > .git/refs/heads/master
-spatel1-mn1:school-of-sre spatel1$ git log --oneline --graph
+$ echo 7f3b00eaa957815884198e2fdfec29361108d6a9 > .git/refs/heads/master
+$ git log --oneline --graph
 * 7f3b00e (HEAD -> master) adding file 2
 * df2fb7a adding file 1
 ```

--- a/courses/git/github-hooks.md
+++ b/courses/git/github-hooks.md
@@ -17,7 +17,7 @@ GitHub has written nice guides and tutorials about this and you can refer them h
 Git has another nice feature called hooks. Hooks are basically scripts which will be called when a certain event happens. Here is where hooks are located:
 
 ```bash
-spatel1-mn1:school-of-sre spatel1$ ls .git/hooks/
+$ ls .git/hooks/
 applypatch-msg.sample     fsmonitor-watchman.sample pre-applypatch.sample     pre-push.sample           pre-receive.sample        update.sample
 commit-msg.sample         post-update.sample        pre-commit.sample         pre-rebase.sample         prepare-commit-msg.sample
 ```
@@ -25,16 +25,16 @@ commit-msg.sample         post-update.sample        pre-commit.sample         pr
 Names are self explanatory. These hooks are useful when you want to do certain things when a certain event happens. If you want to run tests before pushing code, you would want to setup `pre-push` hooks. Let's try to create a pre commit hook.
 
 ```bash
-spatel1-mn1:school-of-sre spatel1$ echo "echo this is from pre commit hook" > .git/hooks/pre-commit
-spatel1-mn1:school-of-sre spatel1$ chmod +x .git/hooks/pre-commit
+$ echo "echo this is from pre commit hook" > .git/hooks/pre-commit
+$ chmod +x .git/hooks/pre-commit
 ```
 
 We basically create a file called `pre-commit` in hooks folder and make it executable. Now if we make a commit, we should see the message getting printed.
 
 ```bash
-spatel1-mn1:school-of-sre spatel1$ echo "sample file" > sample.txt
-spatel1-mn1:school-of-sre spatel1$ git add sample.txt
-spatel1-mn1:school-of-sre spatel1$ git commit -m "adding sample file"
+$ echo "sample file" > sample.txt
+$ git add sample.txt
+$ git commit -m "adding sample file"
 this is from pre commit hook     # <===== THE MESSAGE FROM HOOK EXECUTION
 [master 9894e05] adding sample file
 1 file changed, 1 insertion(+)

--- a/courses/python_web/intro.md
+++ b/courses/python_web/intro.md
@@ -47,14 +47,14 @@ Well, Java's compiler is more strict and sophisticated. As you might know Java i
 
 ```bash
 # Create a Hello World
-spatel1-mn1:tmp spatel1$ echo "print('hello world')" > hello_world.py
+$ echo "print('hello world')" > hello_world.py
 
 # Making sure it runs
-spatel1-mn1:tmp spatel1$ python3 hello_world.py
+$ python3 hello_world.py
 hello world
 
 # The bytecode of the given program
-spatel1-mn1:tmp spatel1$ python -m dis hello_world.py
+$ python -m dis hello_world.py
  1           0 LOAD_NAME                0 (print)
              2 LOAD_CONST               0 ('hello world')
              4 CALL_FUNCTION            1

--- a/courses/python_web/url-shorten-app.md
+++ b/courses/python_web/url-shorten-app.md
@@ -83,13 +83,13 @@ OUTPUT:
 
 ===> SHORTENING
 
-spatel1-mn1:tmp spatel1$ curl localhost:5000/shorten -H "content-type: application/json" --data '{"url":"https://linkedin.com"}'
+$ curl localhost:5000/shorten -H "content-type: application/json" --data '{"url":"https://linkedin.com"}'
 Shortened: r/a62a4
 
 
 ===> REDIRECTING, notice the response code 302 and the location header
 
-spatel1-mn1:tmp spatel1$ curl localhost:5000/r/a62a4 -v
+$ curl localhost:5000/r/a62a4 -v
 * Uses proxy env variable NO_PROXY == '127.0.0.1'
 *   Trying ::1...
 * TCP_NODELAY set


### PR DESCRIPTION
This fixes this issue #83
I made this commit by running a find replace with the pattern
'^.*spatel1\$'
and replaced it with
'$'