### PR TITLE
Fixed Issue #127 : Redirection issue and a typo in monitoring script

### DIFF
--- a/courses/level102/containerization_and_orchestration/intro_to_containers.md
+++ b/courses/level102/containerization_and_orchestration/intro_to_containers.md
@@ -177,7 +177,7 @@ This limit is too low and hence most of the processes attached to mem_group shou
 
 The process is OOM killed as expected. You can confirm the same with dmesg logs (mm_fault_error).
 
-If you want to try out a more in-depth exercise on cgroups, check out [this tutorial from Geeks for Geeks](geeksforgeeks.org/linux-virtualization-resource-throttling-using-cgroups/).
+If you want to try out a more in-depth exercise on cgroups, check out [this tutorial from Geeks for Geeks](https://geeksforgeeks.org/linux-virtualization-resource-throttling-using-cgroups/).
 
 
 Let’s come back to containers again. Containers share the same kernel as the underlying host operating system and provide an isolated environment of the application within. Cgroups help in managing resources used by processes within a container and namespaces help isolate network stack, pids, users, group ids and mount points in a container from another container running on the same host.

--- a/courses/level102/linux_intermediate/bashscripting.md
+++ b/courses/level102/linux_intermediate/bashscripting.md
@@ -158,7 +158,7 @@ We usually come up with tasks that are mostly repetitive, looping helps us to co
 | until | until \[ expression \] <br><br>do <br><br>    \[ until\_block\_to_execute \]<br><br>done |
 
 ```
-!/bin/bash
+#!/bin/bash
 #Script to monitor the server
 
 hosts=`cat host_list`


### PR DESCRIPTION
For 
1. Added **https://** before the GFG link, so the site doesn't go Error 404.
2. Added Missing '#' in the monitoring script.

More details in Issue #127 