### PR TITLE
ci job: pin python version to 3.9

### DIFF
--- a/.github/workflows/gh-deploy.yml
+++ b/.github/workflows/gh-deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: '3.9'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
There are breaking changes with 3.10 which is failing the ci job. details in #129

Python 3.9 worked for last job https://github.com/linkedin/school-of-sre/runs/3321682747?check_suite_focus=true

docs on version numbers: https://github.com/actions/setup-python#specifying-a-python-version