### PR TITLE
Reorder the linux file system information to reflect the same order 

### DIFF
--- a/courses/level101/linux_basics/command_line_basics.md
+++ b/courses/level101/linux_basics/command_line_basics.md
@@ -35,21 +35,23 @@ files or user related files.
 
 ![](images/linux/commands/image17.png)
   
-  bin   | The executable program of most commonly used commands reside in bin directory  
-  
-  sbin  | This directory contains programs used for system administration.
-  
-  home  | This directory contains user related files and directories.
-  
-  lib   | This directory contains all the library files
-  
+  bin   | The executable program of most commonly used commands reside in bin directory
+
+  dev   | This directory contains files related to devices on the system  
+
   etc   | This directory contains all the system configuration files
-  
+
+  home  | This directory contains user related files and directories.
+
+  lib   | This directory contains all the library files
+
+  mnt   | This directory contains files related to mounted devices on the system
+
   proc  | This directory contains files related to the running processes on the system
   
-  dev   | This directory contains files related to devices on the system
+  root  | This directory contains root user related files and directories.
   
-  mnt   | This directory contains files related to mounted devices on the system
+  sbin  | This directory contains programs used for system administration.
   
   tmp   | This directory is used to store temporary files on the system
   

--- a/courses/level101/linux_basics/intro.md
+++ b/courses/level101/linux_basics/intro.md
@@ -79,7 +79,7 @@ and system utilities. The Linux kernel was independently developed and
 released by Linus Torvalds. The Linux kernel is free and open-source -
 [https://github.com/torvalds/linux](https://github.com/torvalds/linux)
 
-Linux is a kernel and and not a complete operating system. Linux kernel is combined with GNU system to make a complete operating system. Therefore, linux based operating systems are also called as GNU/Linux systems. GNU is an extensive collection of free softwares like compiler, debugger, C library etc.
+Linux is a kernel and not a complete operating system. Linux kernel is combined with GNU system to make a complete operating system. Therefore, linux based operating systems are also called as GNU/Linux systems. GNU is an extensive collection of free softwares like compiler, debugger, C library etc.
 [Linux and the GNU  System](https://www.gnu.org/gnu/linux-and-gnu.en.html)
 
 History of Linux -

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 mkdocs==1.1.2
 mkdocs-material==6.2.8
+jinja2==3.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 mkdocs==1.1.2
 mkdocs-material==6.2.8
-jinja2==3.0.3
+jinja2<3.1.0


### PR DESCRIPTION
## Why

 The order of directory in the Linux file system organization image and text under the image do not match. Along with that `/root` directory information is not provided.
 
 As a new user tries to build mkdocs, they are getting an error. This will fix it.

<img width="541" alt="Screen Shot 2022-09-23 at 4 24 30 PM" src="https://user-images.githubusercontent.com/4469824/191945937-4e2cb43c-3e2c-42e8-8736-6fe8059cc565.png">


## What is changing

* By reordering the file system to match the order in the picture makes it more user readable.  And `/root` is added.
* `mkdocs build` command fails with the error message `AttributeError: module 'jinja2' has no attribute 'contextfilter'`. jinja2 added to requirement.txt and set to 3.0.3
*  Multiple "and" in the `What are Linux operating systems` section.

## Changes 

<img width="713" alt="Screen Shot 2022-09-23 at 4 23 44 PM" src="https://user-images.githubusercontent.com/4469824/191945815-414308e4-a288-4405-b093-77dab832a4c5.png">



